### PR TITLE
feat(hub): unlimited invite expiry

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,11 +113,11 @@ model hubs {
 }
 
 model hubInvites {
-  id      String   @id @default(auto()) @map("_id") @db.ObjectId
-  code    String   @unique @default(nanoid(10))
-  expires DateTime
-  hub     hubs     @relation(fields: [hubId], references: [id])
-  hubId   String   @db.ObjectId
+  id        String @id @default(auto()) @map("_id") @db.ObjectId
+  code      String @unique @default(nanoid(10))
+  expiresAt Int?
+  hub       hubs   @relation(fields: [hubId], references: [id])
+  hubId     String @db.ObjectId
 }
 
 model originalMessages {

--- a/src/scripts/tasks/deleteExpiredInvites.ts
+++ b/src/scripts/tasks/deleteExpiredInvites.ts
@@ -1,6 +1,6 @@
 import db from '../../utils/Db.js';
 
 export default async () => {
-  const olderThan1h = new Date(Date.now() - 60 * 60 * 1_000);
-  await db.hubInvites.deleteMany({ where: { expires: { lte: olderThan1h } } }).catch(() => null);
+  const olderThan1h = Date.now() - 60 * 60 * 1_000;
+  await db.hubInvites.deleteMany({ where: { expiresAt: { lte: olderThan1h } } }).catch(() => null);
 };


### PR DESCRIPTION
Adds ability to not set invite expiry (never expiring invite)
- [ ] Must first update existing prod db data to accommodate the new schema and this work (change field type from date to int)


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

## TL;DR
This pull request updates the `hubInvites` model in the Prisma schema, adds autocomplete functionality to the invite code in the `Hub` class, modifies the `Invite` class to handle invite expiration time, and updates the `deleteExpiredInvites` task to use the new `expiresAt` field.

## What changed
- Updated the `hubInvites` model in the Prisma schema to include an `expiresAt` field of type `Int?`.
- Added autocomplete functionality to the invite code in the `Hub` class.
- Modified the `Invite` class to handle invite expiration time using the `expiresAt` field.
- Updated the `deleteExpiredInvites` task to use the `expiresAt` field for deleting expired invites.

## How to test
1. Update the Prisma schema with the changes to the `hubInvites` model.
2. Test the autocomplete functionality for the invite code in the `Hub` class by entering a valid code.
3. Verify that the `Invite` class correctly handles invite expiration time based on the `expiresAt` field.
4. Run the `deleteExpiredInvites` task and ensure that expired invites are deleted based on the `expiresAt` field.

## Why make this change
- The addition of the `expiresAt` field in the `hubInvites` model allows for more flexibility in handling invite expiration times.
- The autocomplete functionality in the `Hub` class improves user experience when entering invite codes.
- Handling invite expiration time in the `Invite` class ensures that invites are managed effectively.
- Updating the `deleteExpiredInvites` task to use the `expiresAt` field aligns with the changes made to the `hubInvites` model.
</details>