### PR TITLE
feat(cache): replace `cacheClient` with `getRedis()`

### DIFF
--- a/src/modules/CooldownService.ts
+++ b/src/modules/CooldownService.ts
@@ -1,10 +1,13 @@
-import cacheClient from '#main/utils/cache/cacheClient.js';
+import getRedis from '#utils/Redis.js';
 import { RedisKeys } from '#main/config/Constants.js';
 
 /** Manage and store individual cooldowns */
 export default class CooldownService {
+  private redisClient = getRedis();
+  private readonly prefix = RedisKeys.cooldown;
+
   private getKey(id: string) {
-    return `${RedisKeys.cooldown}:${id}`;
+    return `${this.prefix}:${id}`;
   }
   /**
    * Set a cooldown
@@ -12,17 +15,17 @@ export default class CooldownService {
    * @param ms The duration of the cooldown in milliseconds
    */
   public async setCooldown(id: string, ms: number) {
-    await cacheClient.set(this.getKey(id), Date.now() + ms, 'PX', ms);
+    await this.redisClient.set(this.getKey(id), Date.now() + ms, 'PX', ms);
   }
 
   /** Get a cooldown */
   public async getCooldown(id: string) {
-    return parseInt((await cacheClient.get(this.getKey(id))) || '0');
+    return parseInt((await this.redisClient.get(this.getKey(id))) || '0');
   }
 
   /** Delete a cooldown */
   public async deleteCooldown(id: string) {
-    await cacheClient.del(this.getKey(id));
+    await this.redisClient.del(this.getKey(id));
   }
 
   /** Get the remaining cooldown in milliseconds */

--- a/src/utils/ConnectedListUtils.ts
+++ b/src/utils/ConnectedListUtils.ts
@@ -1,9 +1,9 @@
 import { RedisKeys } from '#main/config/Constants.js';
-import Logger from '#main/utils/Logger.js';
-import cacheClient from '#main/utils/cache/cacheClient.js';
+import Logger from '#utils/Logger.js';
+import getRedis from '#utils/Redis.js';
 import type { connectedList, Prisma } from '@prisma/client';
-import db from '#main/utils/Db.js';
-import { cacheData, getCachedData } from '#main/utils/cache/cacheUtils.js';
+import db from '#utils/Db.js';
+import { cacheData, getCachedData } from '#utils/cache/cacheUtils.js';
 
 type whereUniuqeInput = Prisma.connectedListWhereUniqueInput;
 type whereInput = Prisma.connectedListWhereInput;
@@ -11,7 +11,7 @@ type dataInput = Prisma.connectedListUpdateInput;
 type ConnectionOperation = 'create' | 'modify' | 'delete';
 
 const purgeConnectionCache = async (channelId: string) =>
-  await cacheClient.del(`${RedisKeys.connectionHubId}:${channelId}`);
+  await getRedis().del(`${RedisKeys.connectionHubId}:${channelId}`);
 
 const serializeConnection = (connection: ConvertDatesToString<connectedList>) => ({
   ...connection,
@@ -79,7 +79,7 @@ export const syncHubConnCache = async (
 
 const cacheConnectionHubId = async (connection: connectedList) => {
   if (!connection.connected) {
-    await cacheClient.del(`${RedisKeys.connectionHubId}:${connection.channelId}`);
+    await getRedis().del(`${RedisKeys.connectionHubId}:${connection.channelId}`);
   }
   else {
     await cacheData(

--- a/src/utils/Redis.ts
+++ b/src/utils/Redis.ts
@@ -1,0 +1,11 @@
+import { Redis } from 'ioredis';
+
+// when run usin scripts like registerCmds
+let redisClient: Redis;
+
+export const getRedis = () => {
+  if (!redisClient) redisClient = new Redis(process.env.REDIS_URI as string);
+  return redisClient;
+};
+
+export default getRedis;

--- a/src/utils/cache/cacheClient.ts
+++ b/src/utils/cache/cacheClient.ts
@@ -1,8 +1,0 @@
-// FIXME: Redis being instantiated like this causes it to never disconnect
-
-import { Redis } from 'ioredis';
-
-// when run usin scripts like registerCmds
-const cacheClient = new Redis(process.env.REDIS_URI as string);
-
-export default cacheClient;

--- a/src/utils/moderation/deleteMessage.ts
+++ b/src/utils/moderation/deleteMessage.ts
@@ -1,7 +1,7 @@
 import { RedisKeys } from '#main/config/Constants.js';
-import cacheClient from '#main/utils/cache/cacheClient.js';
-import { cacheData, getCachedData } from '#main/utils/cache/cacheUtils.js';
-import { getHubConnections } from '#main/utils/ConnectedListUtils.js';
+import getRedis from '#utils/Redis.js';
+import { cacheData, getCachedData } from '#utils/cache/cacheUtils.js';
+import { getHubConnections } from '#utils/ConnectedListUtils.js';
 import { broadcastedMessages } from '@prisma/client';
 import { Snowflake, WebhookClient } from 'discord.js';
 
@@ -32,11 +32,11 @@ export const deleteMessageFromHub = async (
     deletedCount++;
   }
 
-  await cacheClient.del(`${RedisKeys.msgDeleteInProgress}:${originalMsgId}`);
+  await getRedis().del(`${RedisKeys.msgDeleteInProgress}:${originalMsgId}`);
   return { deletedCount };
 };
 
 export const isDeleteInProgress = async (originalMsgId: Snowflake) => {
-  const res = await cacheClient.get(`${RedisKeys.msgDeleteInProgress}:${originalMsgId}`);
+  const res = await getRedis().get(`${RedisKeys.msgDeleteInProgress}:${originalMsgId}`);
   return res === 't';
 };

--- a/src/utils/network/storeMessageData.ts
+++ b/src/utils/network/storeMessageData.ts
@@ -1,11 +1,11 @@
-import { updateConnections } from '#main/utils/ConnectedListUtils.js';
+import { updateConnections } from '#utils/ConnectedListUtils.js';
 import { ConnectionMode, RedisKeys } from '#main/config/Constants.js';
-import db from '#main/utils/Db.js';
-import Logger from '#main/utils/Logger.js';
-import cacheClient from '#main/utils/cache/cacheClient.js';
+import db from '#utils/Db.js';
+import Logger from '#utils/Logger.js';
+import getRedis from '#utils/Redis.js';
 import { originalMessages } from '@prisma/client';
 import { APIMessage, Message } from 'discord.js';
-import { getCachedData } from '#main/utils/cache/cacheUtils.js';
+import { getCachedData } from '#utils/cache/cacheUtils.js';
 
 interface ErrorResult {
   webhookURL: string;
@@ -30,7 +30,7 @@ const storeMessageTimestamp = async (message: Message) => {
     { channelId: message.channelId, timestamp: message.createdTimestamp },
   ]);
 
-  await cacheClient.set(`${RedisKeys.msgTimestamp}:all`, data);
+  await getRedis().set(`${RedisKeys.msgTimestamp}:all`, data);
 };
 
 /**


### PR DESCRIPTION
This commit replaces the use of the `cacheClient` module with the `getRedis` module, which provides a direct Redis client. This change was made to improve the maintainability and flexibility of the caching functionality in the application.

The key changes are:

- Replace `cacheClient` with `getRedis()` calls in various files, including `ConnectedListUtils.ts`, `deleteMessage.ts`, `CooldownService.ts`, `storeMessageData.ts`, and `cacheUtils.ts`.
- Remove the `traverseCursor` function from `cacheUtils.ts`, as it is no longer needed with the new Redis client.
- Update the import paths to use the new `#utils` directory structure.

These changes will help to centralize the Redis client usage and make it easier to maintain and update the caching functionality in the future.