### PR TITLE
feat(network-message): Use redis entirely to store messages

### DIFF
--- a/src/commands/context-menu/translate.ts
+++ b/src/commands/context-menu/translate.ts
@@ -1,7 +1,8 @@
+import { emojis } from '#main/config/Constants.js';
 import BaseCommand from '#main/core/BaseCommand.js';
 import { RegisterInteractionHandler } from '#main/decorators/Interaction.js';
+import { findOriginalMessage, getOriginalMessage } from '#main/utils/network/messageUtils.js';
 import { CustomID } from '#utils/CustomID.js';
-import db from '#utils/Db.js';
 import { t } from '#utils/Locale.js';
 import {
   ActionRowBuilder,
@@ -18,7 +19,6 @@ import {
   TextInputBuilder,
   TextInputStyle,
 } from 'discord.js';
-import { emojis } from '#main/config/Constants.js';
 import { isSupported, translate } from 'google-translate-api-x';
 
 export default class Translate extends BaseCommand {
@@ -41,12 +41,8 @@ export default class Translate extends BaseCommand {
 
     const target = interaction.targetMessage;
 
-    const originalMsg = (
-      await db.broadcastedMessages.findFirst({
-        where: { messageId: target.id },
-        include: { originalMsg: true },
-      })
-    )?.originalMsg;
+    const originalMsg =
+      (await getOriginalMessage(target.id)) ?? (await findOriginalMessage(target.id));
 
     if (!originalMsg) {
       await interaction.editReply(t('errors.unknownNetworkMessage', locale, { emoji: emojis.no }));

--- a/src/commands/slash/Information/stats.ts
+++ b/src/commands/slash/Information/stats.ts
@@ -1,6 +1,6 @@
 import BaseCommand from '#main/core/BaseCommand.js';
 import { RegisterInteractionHandler } from '#main/decorators/Interaction.js';
-import Constants, { emojis } from '#main/config/Constants.js';
+import Constants, { emojis, RedisKeys } from '#main/config/Constants.js';
 import { CustomID } from '#utils/CustomID.js';
 import db from '#utils/Db.js';
 import { msToReadable } from '#utils/Utils.js';
@@ -16,6 +16,7 @@ import {
   time,
 } from 'discord.js';
 import { cpus, totalmem } from 'os';
+import getRedis from '#main/utils/Redis.js';
 
 export default class Stats extends BaseCommand {
   override readonly data = {
@@ -29,7 +30,7 @@ export default class Stats extends BaseCommand {
     await interaction.deferReply();
 
     const totalHubs = await db.hub.count();
-    const totalNetworkMessages = await db.originalMessages.count();
+    const totalNetworkMessages = await getRedis().hkeys(RedisKeys.message);
 
     const guildCount: number[] =
       await interaction.client.cluster.fetchClientValues('guilds.cache.size');
@@ -72,7 +73,7 @@ export default class Stats extends BaseCommand {
           name: 'Hub Stats',
           value: stripIndents`
             Total Hubs: ${totalHubs}
-            Messages (Today): ${totalNetworkMessages}`,
+            Messages (Today): ${totalNetworkMessages.length}`,
           inline: false,
         },
       ]);

--- a/src/commands/slash/Staff/purge.ts
+++ b/src/commands/slash/Staff/purge.ts
@@ -1,14 +1,7 @@
-import { emojis } from '#main/config/Constants.js';
 import BaseCommand from '#main/core/BaseCommand.js';
-import db from '#utils/Db.js';
-import { deleteMsgsFromDb, handleError, msToReadable, resolveEval } from '#utils/Utils.js';
-import { broadcastedMessages } from '@prisma/client';
-import { stripIndents } from 'common-tags';
 import {
   APIApplicationCommandBasicOption,
   ApplicationCommandOptionType,
-  ChatInputCommandInteraction,
-  EmbedBuilder,
   PermissionFlagsBits,
   RESTPostAPIApplicationCommandsJSONBody,
 } from 'discord.js';
@@ -101,183 +94,184 @@ export default class Purge extends BaseCommand {
     ],
   };
 
-  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-    const isOnCooldown = await this.checkOrSetCooldown(interaction);
-    if (isOnCooldown) return;
+  async execute(): Promise<void> {
+    // FIXME: Use redis L
+    // const isOnCooldown = await this.checkOrSetCooldown(interaction);
+    // if (isOnCooldown) return;
 
-    await interaction.deferReply({ fetchReply: true });
+    // await interaction.deferReply({ fetchReply: true });
 
-    const subcommand = interaction.options.getSubcommand();
-    const limit = interaction.options.getInteger('limit') || 100;
-    const channelInHub = await db.connectedList.findFirst({
-      where: { channelId: interaction.channelId, connected: true },
-    });
+    // const subcommand = interaction.options.getSubcommand();
+    // const limit = interaction.options.getInteger('limit') || 100;
+    // const channelInHub = await db.connectedList.findFirst({
+    //   where: { channelId: interaction.channelId, connected: true },
+    // });
 
-    const isMod = db.hub.findFirst({
-      where: {
-        OR: [
-          { moderators: { some: { userId: interaction.user.id } } },
-          { ownerId: interaction.user.id },
-        ],
-      },
-    });
+    // const isMod = db.hub.findFirst({
+    //   where: {
+    //     OR: [
+    //       { moderators: { some: { userId: interaction.user.id } } },
+    //       { ownerId: interaction.user.id },
+    //     ],
+    //   },
+    // });
 
-    if (!isMod) {
-      await interaction.editReply(
-        `${emojis.no} You must be a moderator or owner of this hub to use this command.`,
-      );
-      return;
-    }
+    // if (!isMod) {
+    //   await interaction.editReply(
+    //     `${emojis.no} You must be a moderator or owner of this hub to use this command.`,
+    //   );
+    //   return;
+    // }
 
-    if (!channelInHub) {
-      await interaction.editReply({
-        content: 'This channel is not connected to a hub.',
-      });
-      return;
-    }
+    // if (!channelInHub) {
+    //   await interaction.editReply({
+    //     content: 'This channel is not connected to a hub.',
+    //   });
+    //   return;
+    // }
 
-    let messagesInDb: broadcastedMessages[] = [];
+    // let messagesInDb: broadcastedMessages[] = [];
 
-    switch (subcommand) {
-      case 'server': {
-        const serverId = interaction.options.getString('server', true);
-        const serverRes = await db.originalMessages.findMany({
-          where: { serverId, hubId: channelInHub.hubId },
-          select: { broadcastMsgs: true },
-          orderBy: { createdAt: 'desc' },
-          take: limit,
-        });
+    // switch (subcommand) {
+    //   case 'server': {
+    //     const serverId = interaction.options.getString('server', true);
+    //     const serverRes = await db.originalMessages.findMany({
+    //       where: { serverId, hubId: channelInHub.hubId },
+    //       select: { broadcastMsgs: true },
+    //       orderBy: { createdAt: 'desc' },
+    //       take: limit,
+    //     });
 
-        messagesInDb = serverRes.flatMap((i) => i.broadcastMsgs);
-        break;
-      }
+    //     messagesInDb = serverRes.flatMap((i) => i.broadcastMsgs);
+    //     break;
+    //   }
 
-      case 'user': {
-        const authorId = interaction.options.getString('user', true);
-        const userRes = await db.originalMessages.findMany({
-          where: { authorId, hubId: channelInHub.hubId },
-          select: { broadcastMsgs: true },
-          orderBy: { messageId: 'desc' },
-          take: limit,
-        });
+    //   case 'user': {
+    //     const authorId = interaction.options.getString('user', true);
+    //     const userRes = await db.originalMessages.findMany({
+    //       where: { authorId, hubId: channelInHub.hubId },
+    //       select: { broadcastMsgs: true },
+    //       orderBy: { messageId: 'desc' },
+    //       take: limit,
+    //     });
 
-        messagesInDb = userRes.flatMap((i) => i.broadcastMsgs);
-        break;
-      }
-      case 'after': {
-        const messageId = interaction.options.getString('message', true);
-        const fetchedMsg = await interaction.channel?.messages.fetch(messageId).catch(() => null);
+    //     messagesInDb = userRes.flatMap((i) => i.broadcastMsgs);
+    //     break;
+    //   }
+    //   case 'after': {
+    //     const messageId = interaction.options.getString('message', true);
+    //     const fetchedMsg = await interaction.channel?.messages.fetch(messageId).catch(() => null);
 
-        if (fetchedMsg) {
-          const messagesRes = await db.originalMessages.findMany({
-            where: { hubId: channelInHub.hubId, createdAt: { gte: fetchedMsg.createdAt } },
-            take: limit,
-            select: { broadcastMsgs: true },
-          });
+    //     if (fetchedMsg) {
+    //       const messagesRes = await db.originalMessages.findMany({
+    //         where: { hubId: channelInHub.hubId, createdAt: { gte: fetchedMsg.createdAt } },
+    //         take: limit,
+    //         select: { broadcastMsgs: true },
+    //       });
 
-          messagesInDb = messagesRes.flatMap((m) => m.broadcastMsgs);
-        }
-        break;
-      }
-      case 'replies': {
-        const messageReference = interaction.options.getString('replied-to', true);
-        messagesInDb = (
-          await db.originalMessages.findMany({
-            where: { messageReference },
-            include: { broadcastMsgs: true },
-          })
-        ).flatMap((i) => i.broadcastMsgs);
+    //       messagesInDb = messagesRes.flatMap((m) => m.broadcastMsgs);
+    //     }
+    //     break;
+    //   }
+    //   case 'replies': {
+    //     const messageReference = interaction.options.getString('replied-to', true);
+    //     messagesInDb = (
+    //       await db.originalMessages.findMany({
+    //         where: { messageReference },
+    //         include: { broadcastMsgs: true },
+    //       })
+    //     ).flatMap((i) => i.broadcastMsgs);
 
-        break;
-      }
-      case 'any':
-        messagesInDb = (
-          await db.originalMessages.findMany({
-            where: { hubId: channelInHub.hubId },
-            orderBy: { messageId: 'desc' },
-            include: { broadcastMsgs: true },
-            take: limit,
-          })
-        ).flatMap((i) => i.broadcastMsgs);
-        break;
+    //     break;
+    //   }
+    //   case 'any':
+    //     messagesInDb = (
+    //       await db.originalMessages.findMany({
+    //         where: { hubId: channelInHub.hubId },
+    //         orderBy: { messageId: 'desc' },
+    //         include: { broadcastMsgs: true },
+    //         take: limit,
+    //       })
+    //     ).flatMap((i) => i.broadcastMsgs);
+    //     break;
 
-      default:
-        break;
-    }
+    //   default:
+    //     break;
+    // }
 
-    if (!messagesInDb || messagesInDb.length < 1) {
-      await interaction.editReply(
-        'Messages to purge not found; messages sent over 24 hours ago have been automatically removed.',
-      );
-      return;
-    }
+    // if (!messagesInDb || messagesInDb.length < 1) {
+    //   await interaction.editReply(
+    //     'Messages to purge not found; messages sent over 24 hours ago have been automatically removed.',
+    //   );
+    //   return;
+    // }
 
-    const startTime = performance.now();
-    const allNetworks = await db.connectedList.findMany({
-      where: { hubId: channelInHub.hubId, connected: true },
-    });
+    // const startTime = performance.now();
+    // const allNetworks = await db.connectedList.findMany({
+    //   where: { hubId: channelInHub.hubId, connected: true },
+    // });
 
-    const promiseResults = allNetworks.map(async (network) => {
-      try {
-        // TODO: Find a better way to do this
-        // because we are doing this in all the shards, which is double the work
-        const evalRes = await interaction.client.cluster.broadcastEval(
-          async (client, ctx) => {
-            const channel = await client.channels.fetch(ctx.channelId);
+    // const promiseResults = allNetworks.map(async (network) => {
+    //   try {
+    //     // TODO: Find a better way to do this
+    //     // because we are doing this in all the shards, which is double the work
+    //     const evalRes = await interaction.client.cluster.broadcastEval(
+    //       async (client, ctx) => {
+    //         const channel = await client.channels.fetch(ctx.channelId);
 
-            // using type as 0 because we cant access ChannelType enum inside eval
-            if (channel?.type === 0 || channel?.isThread()) {
-              const messageIds = ctx.messagesInDb
-                .filter(({ channelId }) => channelId === channel.id)
-                .map(({ messageId }) => messageId);
+    //         // using type as 0 because we cant access ChannelType enum inside eval
+    //         if (channel?.type === 0 || channel?.isThread()) {
+    //           const messageIds = ctx.messagesInDb
+    //             .filter(({ channelId }) => channelId === channel.id)
+    //             .map(({ messageId }) => messageId);
 
-              if (messageIds.length < 1) return [];
+    //           if (messageIds.length < 1) return [];
 
-              await channel.bulkDelete(messageIds);
-              return messageIds;
-            }
-            return null;
-          },
-          { context: { channelId: network.channelId, messagesInDb } },
-        );
+    //           await channel.bulkDelete(messageIds);
+    //           return messageIds;
+    //         }
+    //         return null;
+    //       },
+    //       { context: { channelId: network.channelId, messagesInDb } },
+    //     );
 
-        return resolveEval(evalRes) || [];
-      }
-      catch (e) {
-        handleError(e);
-      }
+    //     return resolveEval(evalRes) || [];
+    //   }
+    //   catch (e) {
+    //     handleError(e);
+    //   }
 
-      return [];
-    });
+    //   return [];
+    // });
 
-    const results = await Promise.all(promiseResults);
-    const deletedMessages = results.reduce((acc, cur) => acc + cur.length, 0);
-    const failedMessages = results.reduce((acc, cur) => (acc + cur.length > 0 ? 0 : 1), 0);
-    const timeTaken = performance.now() - startTime;
+    // const results = await Promise.all(promiseResults);
+    // const deletedMessages = results.reduce((acc, cur) => acc + cur.length, 0);
+    // const failedMessages = results.reduce((acc, cur) => (acc + cur.length > 0 ? 0 : 1), 0);
+    // const timeTaken = performance.now() - startTime;
 
-    const resultEmbed = new EmbedBuilder()
-      .setDescription(
-        stripIndents`
-        ### ${emojis.delete} Purge Results
+    // const resultEmbed = new EmbedBuilder()
+    //   .setDescription(
+    //     stripIndents`
+    //     ### ${emojis.delete} Purge Results
 
-        Finished purging from **${allNetworks.length}** networks in \`${msToReadable(timeTaken)}\`.
-      `,
-      )
-      .addFields([
-        { name: 'Total Purged', value: `\`\`\`js\n${deletedMessages}\`\`\``, inline: true },
-        { name: 'Errored Purges', value: `\`\`\`js\n${failedMessages}\`\`\``, inline: true },
-        { name: 'Purge Limit', value: `\`\`\`js\n${limit || 'None'}\`\`\``, inline: true },
-      ])
-      .setFooter({
-        text: `Purged By: ${interaction.user.username}`,
-        iconURL: interaction.user.avatarURL() || undefined,
-      })
-      .setTimestamp()
-      .setColor('Red');
+    //     Finished purging from **${allNetworks.length}** networks in \`${msToReadable(timeTaken)}\`.
+    //   `,
+    //   )
+    //   .addFields([
+    //     { name: 'Total Purged', value: `\`\`\`js\n${deletedMessages}\`\`\``, inline: true },
+    //     { name: 'Errored Purges', value: `\`\`\`js\n${failedMessages}\`\`\``, inline: true },
+    //     { name: 'Purge Limit', value: `\`\`\`js\n${limit || 'None'}\`\`\``, inline: true },
+    //   ])
+    //   .setFooter({
+    //     text: `Purged By: ${interaction.user.username}`,
+    //     iconURL: interaction.user.avatarURL() || undefined,
+    //   })
+    //   .setTimestamp()
+    //   .setColor('Red');
 
-    await interaction.followUp({ embeds: [resultEmbed] });
+    // await interaction.followUp({ embeds: [resultEmbed] });
 
-    const succeededMessages = results?.filter((i) => i.length > 0).flat();
-    await deleteMsgsFromDb(succeededMessages);
+    // const succeededMessages = results?.filter((i) => i.length > 0).flat();
+    // await deleteMsgsFromDb(succeededMessages);
   }
 }

--- a/src/config/Constants.ts
+++ b/src/config/Constants.ts
@@ -26,12 +26,18 @@ export const enum RedisKeys {
   userInfraction = 'UserInfraction',
   serverInfraction = 'ServerInfraction',
   hubLogConfig = 'hubLogConfig',
+  message = 'message',
+  broadcasts = 'broadcasts',
+  messageReverse = 'messageReverse',
 }
 
 export const enum ConnectionMode {
   Compact = 0,
   Embed = 1,
 }
+
+/** Unicode emojis for numbers */
+export const numberEmojis = ['0️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟'] as const;
 
 export default {
   isDevBuild: process.env.NODE_ENV === 'development',

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,8 +1,10 @@
+import { ConnectionMode } from '#main/config/Constants.js';
 import BaseEventListener from '#main/core/BaseEventListener.js';
 import HubSettingsManager from '#main/managers/HubSettingsManager.js';
+import { generateJumpButton as getJumpButton } from '#utils/ComponentUtils.js';
 import { getConnectionHubId, getHubConnections } from '#utils/ConnectedListUtils.js';
-import { ConnectionMode } from '#main/config/Constants.js';
 import db from '#utils/Db.js';
+import { getAttachmentURL } from '#utils/ImageUtils.js';
 import {
   buildNetworkEmbed,
   getReferredContent,

--- a/src/tasks/pauseIdleConnections.ts
+++ b/src/tasks/pauseIdleConnections.ts
@@ -1,5 +1,5 @@
 import { emojis } from '#main/config/Constants.js';
-import { updateConnection } from '#utils/ConnectedListUtils.js';
+import { updateConnections } from '#utils/ConnectedListUtils.js';
 import db from '#utils/Db.js';
 import { InfoEmbed } from '#utils/EmbedUtils.js';
 import Logger from '#utils/Logger.js';
@@ -24,11 +24,15 @@ export default async (manager: ClusterManager) => {
     button: APIActionRowComponent<APIButtonComponent>;
   }[] = [];
 
+  const channelIds: string[] = [];
+
   // Loop through the data
-  connections.forEach(async ({ channelId, lastActive }) => {
+  connections.forEach(({ channelId, lastActive }) => {
     Logger.info(
       `[InterChat]: Pausing inactive connection ${channelId} due to inactivity since ${lastActive?.toLocaleString()} - ${new Date().toLocaleString()}`,
     );
+
+    channelIds.push(channelId);
 
     // Create the button
     reconnectButtonArr.push({
@@ -37,10 +41,10 @@ export default async (manager: ClusterManager) => {
         customCustomId: 'inactiveConnect',
       }).toJSON(),
     });
-
-    // disconnect the channel
-    await updateConnection({ channelId }, { connected: false });
   });
+
+  // disconnect the channel
+  await updateConnections({ channelId: { in: channelIds } }, { connected: false });
 
   const embed = new InfoEmbed()
     .removeTitle()

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,9 +1,8 @@
 import Constants from '#main/config/Constants.js';
+import type { RemoveMethods, ThreadParentChannel } from '#types/index.d.ts';
 import { CustomID } from '#utils/CustomID.js';
-import db from '#utils/Db.js';
 import { ErrorEmbed } from '#utils/EmbedUtils.js';
 import Logger from '#utils/Logger.js';
-import type { RemoveMethods, ThreadParentChannel } from '#types/index.d.ts';
 import { captureException } from '@sentry/node';
 import type { ClusterManager } from 'discord-hybrid-sharding';
 import {
@@ -100,25 +99,6 @@ export const getCredits = () => [
 export const checkIfStaff = (userId: string, onlyCheckForDev = false) => {
   const staffMembers = [...Constants.DeveloperIds, ...(onlyCheckForDev ? [] : Constants.StaffIds)];
   return staffMembers.includes(userId);
-};
-
-export const deleteMsgsFromDb = async (broadcastMsgs: string[]) => {
-  // delete all relations first and then delete the hub
-  const msgsToDelete = await db.broadcastedMessages.findMany({
-    where: { messageId: { in: broadcastMsgs } },
-  });
-  if (!msgsToDelete) return null;
-
-  const originalMsgIds = msgsToDelete.map(({ originalMsgId }) => originalMsgId);
-
-  const childrenBatch = db.broadcastedMessages.deleteMany({
-    where: { originalMsgId: { in: originalMsgIds } },
-  });
-  const originalBatch = db.originalMessages.deleteMany({
-    where: { messageId: { in: originalMsgIds } },
-  });
-
-  return await db.$transaction([childrenBatch, originalBatch]);
 };
 
 export const replaceLinks = (string: string, replaceText = '`[LINK HIDDEN]`') =>

--- a/src/utils/hub/utils.ts
+++ b/src/utils/hub/utils.ts
@@ -5,7 +5,7 @@ import {
 } from '#utils/ConnectedListUtils.js';
 import db from '#utils/Db.js';
 import Logger from '#utils/Logger.js';
-import { deleteMsgsFromDb, checkIfStaff } from '#utils/Utils.js';
+import { checkIfStaff } from '#utils/Utils.js';
 import type { Hub } from '@prisma/client';
 import { type WebhookMessageCreateOptions, WebhookClient } from 'discord.js';
 
@@ -48,13 +48,6 @@ export const deleteHubs = async (ids: string[]) => {
   // delete all relations first and then delete the hub
   await deleteConnections({ hubId: { in: ids } });
   await db.hubInvite.deleteMany({ where: { hubId: { in: ids } } });
-  await db.originalMessages
-    .findMany({ where: { hubId: { in: ids } }, include: { broadcastMsgs: true } })
-    .then((m) =>
-      deleteMsgsFromDb(
-        m.map(({ broadcastMsgs }) => broadcastMsgs.map(({ messageId }) => messageId)).flat(),
-      ),
-    );
 
   // finally, delete the hub
   await db.hub.deleteMany({ where: { id: { in: ids } } });

--- a/src/utils/moderation/deleteMessage.ts
+++ b/src/utils/moderation/deleteMessage.ts
@@ -2,8 +2,8 @@ import { RedisKeys } from '#main/config/Constants.js';
 import getRedis from '#utils/Redis.js';
 import { cacheData, getCachedData } from '#utils/cache/cacheUtils.js';
 import { getHubConnections } from '#utils/ConnectedListUtils.js';
-import { broadcastedMessages } from '@prisma/client';
 import { Snowflake, WebhookClient } from 'discord.js';
+import { Broadcast } from '#main/utils/network/messageUtils.js';
 
 export const setDeleteLock = async (messageId: string) => {
   const key = `${RedisKeys.msgDeleteInProgress}:${messageId}` as const;
@@ -14,7 +14,7 @@ export const setDeleteLock = async (messageId: string) => {
 export const deleteMessageFromHub = async (
   hubId: string,
   originalMsgId: string,
-  dbMessagesToDelete: broadcastedMessages[],
+  dbMessagesToDelete: Broadcast[],
 ) => {
   await setDeleteLock(originalMsgId);
 
@@ -22,7 +22,7 @@ export const deleteMessageFromHub = async (
   const hubConnections = await getHubConnections(hubId);
   const hubConnectionsMap = new Map(hubConnections?.map((c) => [c.channelId, c]));
 
-  for await (const dbMsg of dbMessagesToDelete) {
+  for await (const dbMsg of Object.values(dbMessagesToDelete)) {
     const connection = hubConnectionsMap.get(dbMsg.channelId);
     if (!connection) continue;
 

--- a/src/utils/moderation/modActions/handlers/RemoveReactionsHandler.ts
+++ b/src/utils/moderation/modActions/handlers/RemoveReactionsHandler.ts
@@ -1,6 +1,7 @@
 import { emojis } from '#main/config/Constants.js';
 import { ReactionArray } from '#main/types/network.js';
-import { fetchMessageFromDb, ModAction } from '#utils/moderation/modActions/utils.js';
+import { getOriginalMessage } from '#main/utils/network/messageUtils.js';
+import { ModAction, replyWithUnknownMessage } from '#utils/moderation/modActions/utils.js';
 import { updateReactions } from '#utils/reaction/actions.js';
 import sortReactions from '#utils/reaction/sortReactions.js';
 import { ButtonInteraction, Snowflake } from 'discord.js';
@@ -9,14 +10,13 @@ export default class RemoveReactionsHandler implements ModAction {
   async handle(interaction: ButtonInteraction, originalMsgId: Snowflake): Promise<void> {
     await interaction.deferReply({ ephemeral: true });
 
-    const originalMsg = await fetchMessageFromDb(originalMsgId, {
-      broadcastMsgs: true,
-    });
+    const originalMsg = await getOriginalMessage(originalMsgId);
+    if (!originalMsg) {
+      await replyWithUnknownMessage(interaction, 'en');
+      return;
+    }
 
-    if (
-      !originalMsg?.broadcastMsgs?.length ||
-      !sortReactions((originalMsg.reactions as ReactionArray) ?? {}).length
-    ) {
+    if (!sortReactions((originalMsg.reactions as ReactionArray) ?? {}).length) {
       await interaction.followUp({
         content: `${emojis.slash} No reactions to remove.`,
         ephemeral: true,
@@ -24,11 +24,8 @@ export default class RemoveReactionsHandler implements ModAction {
       return;
     }
 
-    await updateReactions(originalMsg?.broadcastMsgs, {});
+    await updateReactions(originalMsg, {});
 
-    await interaction.followUp({
-      content: `${emojis.yes} Reactions removed.`,
-      ephemeral: true,
-    });
+    await interaction.followUp({ content: `${emojis.yes} Reactions removed.`, ephemeral: true });
   }
 }

--- a/src/utils/moderation/modActions/handlers/userBanHandler.ts
+++ b/src/utils/moderation/modActions/handlers/userBanHandler.ts
@@ -1,10 +1,10 @@
 import { RegisterInteractionHandler } from '#main/decorators/Interaction.js';
+import { getOriginalMessage } from '#main/utils/network/messageUtils.js';
 import handleBan from '#utils/banUtls/handleBan.js';
 import { CustomID } from '#utils/CustomID.js';
 import type { supportedLocaleCodes } from '#utils/Locale.js';
 import {
   type ModAction,
-  fetchMessageFromDb,
   replyWithUnknownMessage,
 } from '#utils/moderation/modActions/utils.js';
 import {
@@ -23,7 +23,7 @@ export default class UserBanHandler implements ModAction {
     originalMsgId: Snowflake,
     locale: supportedLocaleCodes,
   ) {
-    const originalMsg = await fetchMessageFromDb(originalMsgId);
+    const originalMsg = await getOriginalMessage(originalMsgId);
 
     if (!originalMsg) {
       await replyWithUnknownMessage(interaction, locale);

--- a/src/utils/moderation/modActions/handlers/viewInfractions.ts
+++ b/src/utils/moderation/modActions/handlers/viewInfractions.ts
@@ -1,10 +1,10 @@
 import UserInfractionManager from '#main/managers/InfractionManager/UserInfractionManager.js';
 import { Pagination } from '#main/modules/Pagination.js';
+import { getOriginalMessage } from '#main/utils/network/messageUtils.js';
 import type { supportedLocaleCodes } from '#utils/Locale.js';
 import { buildInfractionListEmbeds } from '#utils/moderation/infractionUtils.js';
 import {
   type ModAction,
-  fetchMessageFromDb,
   replyWithUnknownMessage,
 } from '#utils/moderation/modActions/utils.js';
 import { type ButtonInteraction, type Snowflake } from 'discord.js';
@@ -17,7 +17,7 @@ export default class ViewInfractionsHandler implements ModAction {
   ) {
     await interaction.deferReply({ ephemeral: true });
 
-    const originalMsg = await fetchMessageFromDb(originalMsgId);
+    const originalMsg = await getOriginalMessage(originalMsgId);
 
     if (!originalMsg) {
       await replyWithUnknownMessage(interaction, locale);

--- a/src/utils/moderation/modActions/modActionsPanel.ts
+++ b/src/utils/moderation/modActions/modActionsPanel.ts
@@ -2,9 +2,9 @@ import Constants, { emojis } from '#main/config/Constants.js';
 import BlacklistManager from '#main/managers/BlacklistManager.js';
 import ServerInfractionManager from '#main/managers/InfractionManager/ServerInfractionManager.js';
 import UserInfractionManager from '#main/managers/InfractionManager/UserInfractionManager.js';
+import { OriginalMessage } from '#main/utils/network/messageUtils.js';
 import { CustomID } from '#utils/CustomID.js';
 import { isDeleteInProgress } from '#utils/moderation/deleteMessage.js';
-import { ModActionsDbMsgT } from '#utils/moderation/modActions/utils.js';
 import { checkIfStaff } from '#utils/Utils.js';
 import { stripIndents } from 'common-tags';
 import {
@@ -108,17 +108,14 @@ const buildInfoEmbed = (username: string, servername: string, opts: BuilderOpts)
     `);
 };
 
-const buildMessage = async (
-  interaction: Interaction,
-  originalMsg: ModActionsDbMsgT & { hubId: string },
-) => {
+const buildMessage = async (interaction: Interaction, originalMsg: OriginalMessage) => {
   const user = await interaction.client.users.fetch(originalMsg.authorId);
-  const server = await interaction.client.fetchGuild(originalMsg.serverId);
+  const server = await interaction.client.fetchGuild(originalMsg.guildId);
   const deleteInProgress = await isDeleteInProgress(originalMsg.messageId);
 
   const { userManager } = interaction.client;
   const userBlManager = new BlacklistManager(new UserInfractionManager(originalMsg.authorId));
-  const serverBlManager = new BlacklistManager(new ServerInfractionManager(originalMsg.serverId));
+  const serverBlManager = new BlacklistManager(new ServerInfractionManager(originalMsg.guildId));
 
   const isUserBlacklisted = Boolean(await userBlManager.fetchBlacklist(originalMsg.hubId));
   const isServerBlacklisted = Boolean(await serverBlManager.fetchBlacklist(originalMsg.hubId));

--- a/src/utils/moderation/modActions/utils.ts
+++ b/src/utils/moderation/modActions/utils.ts
@@ -1,19 +1,13 @@
 import { emojis } from '#main/config/Constants.js';
-import db from '#utils/Db.js';
+import { OriginalMessage } from '#main/utils/network/messageUtils.js';
 import { InfoEmbed } from '#utils/EmbedUtils.js';
 import { type supportedLocaleCodes, t } from '#utils/Locale.js';
-import type { broadcastedMessages, Hub, originalMessages, Prisma } from '@prisma/client';
 import type {
   ButtonInteraction,
   ModalSubmitInteraction,
   RepliableInteraction,
   Snowflake,
 } from 'discord.js';
-
-export type ModActionsDbMsgT = originalMessages & {
-  hub?: Hub | null;
-  broadcastMsgs?: broadcastedMessages[];
-};
 
 export interface ModAction {
   handle(
@@ -23,32 +17,10 @@ export interface ModAction {
   ): Promise<void>;
   handleModal?(
     interaction: ModalSubmitInteraction,
-    originalMsg: ModActionsDbMsgT,
+    originalMsg: OriginalMessage,
     locale: supportedLocaleCodes,
   ): Promise<void>;
 }
-
-export const isValidDbMsgWithHubId = (
-  obj: ModActionsDbMsgT,
-): obj is ModActionsDbMsgT & { hubId: string } => obj.hubId !== null;
-
-export const fetchMessageFromDb = async (
-  messageId: string,
-  include: Prisma.originalMessagesInclude = { hub: false, broadcastMsgs: false },
-): Promise<ModActionsDbMsgT | null> => {
-  let messageInDb = await db.originalMessages.findFirst({ where: { messageId }, include });
-
-  if (!messageInDb) {
-    const broadcastedMsg = await db.broadcastedMessages.findFirst({
-      where: { messageId },
-      include: { originalMsg: { include } },
-    });
-
-    messageInDb = broadcastedMsg?.originalMsg ?? null;
-  }
-
-  return messageInDb;
-};
 
 export async function replyWithUnknownMessage(
   interaction: RepliableInteraction,

--- a/src/utils/network/messageUtils.ts
+++ b/src/utils/network/messageUtils.ts
@@ -1,0 +1,119 @@
+import { RedisKeys } from '#main/config/Constants.js';
+import getRedis from '#main/utils/Redis.js';
+import type { Message, Snowflake } from 'discord.js';
+import isEmpty from 'lodash/isEmpty.js';
+
+export interface OriginalMessage {
+  mode: number;
+  hubId: string;
+  messageId: string;
+  guildId: string;
+  authorId: string;
+  timestamp: number;
+  reactions?: { [key: string]: Snowflake[] };
+  referredMessageId?: string;
+}
+
+export interface Broadcast {
+  mode: number;
+  messageId: string;
+  channelId: string;
+  originalMsgId: string;
+}
+
+export const storeMessage = async (originalMsgId: string, messageData: OriginalMessage) => {
+  const key = `${RedisKeys.message}:${originalMsgId}`;
+  const redis = getRedis();
+
+  await redis.hset(key, messageData);
+  await redis.expire(key, 172800); // 2 days in seconds
+};
+
+export const getOriginalMessage = async (originalMsgId: string) => {
+  const key = `${RedisKeys.message}:${originalMsgId}`;
+  const res = (await getRedis().hgetall(key)) as unknown as OriginalMessage;
+
+  if (isEmpty(res)) return null;
+
+  return res;
+};
+
+export const addBroadcasts = async (
+  hubId: string,
+  originalMsgId: Snowflake,
+  ...broadcasts: Broadcast[]
+) => {
+  const redis = getRedis();
+  const broadcastsKey = `${RedisKeys.broadcasts}:${originalMsgId}:${hubId}`;
+
+  // Single loop to process all broadcast data
+  const { broadcastEntries, reverseLookups } = broadcasts.reduce(
+    (acc, broadcast) => {
+      const { messageId, channelId, mode } = broadcast;
+      const broadcastInfo = JSON.stringify({ mode, messageId, channelId, originalMsgId });
+
+      // Add to broadcasts hash
+      acc.broadcastEntries.push(channelId, broadcastInfo);
+
+      // Prepare reverse lookup
+      acc.reverseLookups.push(
+        `${RedisKeys.messageReverse}:${messageId}`,
+        `${originalMsgId}:${hubId}`,
+      );
+
+      return acc;
+    },
+    { broadcastEntries: [] as string[], reverseLookups: [] as string[] },
+  );
+
+  // Add all broadcasts to the hash in a single operation
+  await redis
+    .multi()
+    .hset(broadcastsKey, ...broadcastEntries)
+    .expire(broadcastsKey, 172800)
+    .mset(...reverseLookups)
+    .exec();
+
+  reverseLookups
+    .filter((_, i) => i % 2 === 0)
+    .forEach(async (key) => {
+      await redis.expire(key, 172800);
+    });
+};
+
+export const getBroadcasts = async (originalMsgId: string, hubId: string) => {
+  const key = `${RedisKeys.broadcasts}:${originalMsgId}:${hubId}`;
+  const broadcasts = await getRedis().hgetall(key);
+  const entries = Object.entries(broadcasts);
+
+  // Parse the JSON strings back into objects
+  return Object.fromEntries(entries.map(([k, v]) => [k, JSON.parse(v)])) as Record<
+    string,
+    Broadcast
+  >;
+};
+
+export const getBroadcast = async (
+  originalMsgId: string,
+  hubId: string,
+  find: { channelId: string },
+) => {
+  const broadcast = await getRedis().hget(
+    `${RedisKeys.broadcasts}:${originalMsgId}:${hubId}`,
+    find.channelId,
+  );
+  return broadcast ? (JSON.parse(broadcast) as Broadcast) : null;
+};
+
+export const findOriginalMessage = async (broadcastedMessageId: string) => {
+  const reverseLookupKey = `${RedisKeys.messageReverse}:${broadcastedMessageId}`;
+  const lookup = await getRedis().get(reverseLookupKey);
+
+  if (!lookup) return null;
+
+  return await getOriginalMessage(lookup);
+};
+
+export const storeMessageTimestamp = async (message: Message) => {
+  await getRedis().hset(`${RedisKeys.msgTimestamp}`, message.channelId, message.createdTimestamp);
+};


### PR DESCRIPTION
This commit improves the handling of referenced messages in the network message
commands. The changes include:

- Use `getOriginalMessage` and `findOriginalMessage` functions to fetch the
  original message data, handling both original and broadcast messages.
- Fetch the hub data directly from the original message data, avoiding
  additional database queries.
- Use the `fetchHub` function to retrieve the hub data, ensuring it is
  available.
- Update the `DeleteMessage` command to use the `broadcasts` property of the
  original message instead of the `broadcastMsgs` property.
- Refactor the `NetworkReactionInteraction` class to use the original message
  data directly, instead of relying on the `broadcastedMessages` table.

The goal of these changes is to improve the efficiency and reliability of the
network message handling, reducing database queries and ensuring consistent
data access.