### PR TITLE
refactor(network): simplify message checks and broadcasting 

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -14,62 +14,96 @@ import {
   getReplyMention,
 } from '#utils/network/messageFormatters.js';
 import { runChecks } from '#utils/network/runChecks.js';
-import storeMessageData, {
-  NetworkWebhookSendResult,
-} from '#utils/network/storeMessageData.js';
+import storeMessageData, { NetworkWebhookSendResult } from '#utils/network/storeMessageData.js';
 import type { BroadcastOpts, ReferredMsgData } from '#utils/network/Types.js';
 import { censor } from '#utils/ProfanityUtils.js';
 import { isHumanMessage, trimAndCensorBannedWebhookWords } from '#utils/Utils.js';
 import { connectedList, Hub } from '@prisma/client';
-import { HexColorString, Message, WebhookClient, WebhookMessageCreateOptions } from 'discord.js';
-import { generateJumpButton } from '#utils/ComponentUtils.js';
-import { getAttachmentURL } from '#utils/ImageUtils.js';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  HexColorString,
+  Message,
+  WebhookClient,
+  WebhookMessageCreateOptions,
+} from 'discord.js';
 
 export default class MessageCreate extends BaseEventListener<'messageCreate'> {
   readonly name = 'messageCreate';
 
   async execute(message: Message) {
-    if (!message.inGuild() || !isHumanMessage(message)) return;
+    if (!this.isValidMessage(message)) return;
 
     const { connection, hubConnections } = await this.getConnectionAndHubConnections(message);
-    if (!connection || !hubConnections) return;
+    if (!connection?.connected || !hubConnections) return;
 
-    const hub = await db.hub.findFirst({ where: { id: connection.hubId } });
+    const hub = await this.getHub(connection.hubId);
     if (!hub) return;
 
     const settings = new HubSettingsManager(hub.id, hub.settings);
     const attachmentURL = await this.resolveAttachmentURL(message);
 
-    // run checks on the message to determine if it can be sent in the network
-    const checksPassed = await runChecks(message, hub, {
-      settings,
-      attachmentURL,
-      totalHubConnections: hubConnections.length,
+    if (
+      !(await runChecks(message, hub, {
+        settings,
+        attachmentURL,
+        totalHubConnections: hubConnections.length,
+      }))
+    ) {
+      return;
+    }
+
+    await this.processMessage(message, hub, hubConnections, settings, connection, attachmentURL);
+  }
+
+  private isValidMessage(message: Message): message is Message<true> {
+    return message.inGuild() && isHumanMessage(message);
+  }
+
+  private async getHub(hubId: string) {
+    return await db.hub.findFirst({
+      where: { id: hubId },
+      include: { msgBlockList: true },
     });
+  }
 
-    if (!checksPassed) return;
-
+  private async processMessage(
+    message: Message<true>,
+    hub: Hub,
+    hubConnections: connectedList[],
+    settings: HubSettingsManager,
+    connection: connectedList,
+    attachmentURL: string | undefined,
+  ) {
     message.channel.sendTyping().catch(() => null);
 
-    // fetch the message being replied-to from discord
-    const referredMessage = message.reference
-      ? await message.fetchReference().catch(() => null)
-      : null;
-
+    const referredMessage = await this.fetchReferredMessage(message);
     const referredMsgData = await getReferredMsgData(referredMessage);
+
     const sendResult = await this.broadcastMessage(message, hub, hubConnections, settings, {
       attachmentURL,
       referredMsgData,
       embedColor: connection.embedColor as HexColorString,
     });
 
-    // store the message in the db
-    const mode = connection.compact ? ConnectionMode.Compact : ConnectionMode.Embed;
+    await this.storeMessage(message, sendResult, connection, referredMsgData);
+  }
+
+  private async fetchReferredMessage(message: Message<true>): Promise<Message | null> {
+    return message.reference ? await message.fetchReference().catch(() => null) : null;
+  }
+
+  private async storeMessage(
+    message: Message<true>,
+    sendResult: NetworkWebhookSendResult[],
+    connection: connectedList,
+    referredMsgData: ReferredMsgData,
+  ) {
     await storeMessageData(
       message,
       sendResult,
       connection.hubId,
-      mode,
+      connection.compact ? ConnectionMode.Compact : ConnectionMode.Embed,
       referredMsgData.dbReferrence,
     );
   }
@@ -80,83 +114,149 @@ export default class MessageCreate extends BaseEventListener<'messageCreate'> {
     hubConnections: connectedList[],
     settings: HubSettingsManager,
     opts: BroadcastOpts,
-  ) {
+  ): Promise<NetworkWebhookSendResult[]> {
     const username = this.getUsername(settings, message);
     const censoredContent = censor(message.content);
     const referredContent = this.getReferredContent(opts.referredMsgData);
-    const { dbReferrence } = opts.referredMsgData;
 
-    const results: NetworkWebhookSendResult[] = await Promise.all(
-      hubConnections.map(async (connection) => {
-        try {
-          const author = { username, avatarURL: message.author.displayAvatarURL() };
-          const reply = dbReferrence?.broadcastMsgs.get(connection.channelId) ?? dbReferrence;
-
-          const jumpButton = reply
-            ? [
-              generateJumpButton(author.username, {
-                channelId: connection.channelId,
-                serverId: connection.serverId,
-                messageId: reply.messageId,
-              }),
-            ]
-            : undefined;
-
-          let messageFormat;
-
-          if (connection.compact) {
-            const contents = {
-              normal: message.content,
-              referred: referredContent,
-              censored: censoredContent,
-            };
-
-            messageFormat = getCompactMessageFormat(connection, opts, {
-              servername: trimAndCensorBannedWebhookWords(message.guild.name),
-              totalAttachments: message.attachments.size,
-              contents,
-              author,
-              jumpButton,
-            });
-          }
-          else {
-            const embeds = buildNetworkEmbed(message, username, censoredContent, {
-              attachmentURL: opts.attachmentURL,
-              referredContent,
-              embedCol: opts.embedColor,
-            });
-
-            messageFormat = getEmbedMessageFormat(connection, hub, { jumpButton, embeds });
-          }
-
-          const replyMention = getReplyMention(opts.referredMsgData.dbReferredAuthor);
-
-          // NOTE: If multiple connections to same hub will be a feature in the future,
-          // checking for only serverId will not be enough
-          if (replyMention && connection.serverId === dbReferrence?.serverId) {
-            messageFormat.content = `${replyMention}, ${messageFormat.content ?? ''}`;
-            messageFormat.allowedMentions = {
-              ...messageFormat.allowedMentions,
-              users: [...(messageFormat.allowedMentions?.users ?? []), dbReferrence.authorId],
-            };
-          }
-
-          const messageRes = await this.sendMessage(connection.webhookURL, messageFormat);
-          const mode = connection.compact ? ConnectionMode.Compact : ConnectionMode.Embed;
-
-          return { messageRes, webhookURL: connection.webhookURL, mode };
-        }
-        catch (e) {
-          return { error: e.message, webhookURL: connection.webhookURL };
-        }
-      }),
+    return await Promise.all(
+      hubConnections.map((connection) =>
+        this.sendToConnection(message, hub, connection, {
+          ...opts,
+          username,
+          censoredContent,
+          referredContent,
+        }),
+      ),
     );
+  }
 
-    return results;
+  private async sendToConnection(
+    message: Message<true>,
+    hub: Hub,
+    connection: connectedList,
+    opts: BroadcastOpts & {
+      referredMsgData: ReferredMsgData;
+      username: string;
+      censoredContent: string;
+      referredContent: string | undefined;
+    },
+  ): Promise<NetworkWebhookSendResult> {
+    try {
+      const messageFormat = this.getMessageFormat(message, connection, hub, opts);
+      const messageRes = await this.sendMessage(connection.webhookURL, messageFormat);
+      const mode = connection.compact ? ConnectionMode.Compact : ConnectionMode.Embed;
+
+      return { messageRes, webhookURL: connection.webhookURL, mode };
+    }
+    catch (e) {
+      return { error: e.message, webhookURL: connection.webhookURL };
+    }
+  }
+
+  private getMessageFormat(
+    message: Message<true>,
+    connection: connectedList,
+    hub: Hub,
+    opts: BroadcastOpts & {
+      username: string;
+      censoredContent: string;
+      referredContent: string | undefined;
+      referredMsgData: ReferredMsgData;
+    },
+  ): WebhookMessageCreateOptions {
+    const { dbReferrence } = opts.referredMsgData;
+    const author = { username: opts.username, avatarURL: message.author.displayAvatarURL() };
+    const jumpButton = this.getJumpButton(author.username, connection, dbReferrence);
+
+    const messageFormat = connection.compact
+      ? this.getCompactFormat(message, connection, opts, author, jumpButton)
+      : this.getEmbedFormat(message, connection, hub, opts, jumpButton);
+
+    return this.addReplyMention(messageFormat, connection, opts.referredMsgData);
+  }
+
+  private getJumpButton(
+    username: string,
+    { channelId, serverId }: connectedList,
+    dbReferrence: ReferredMsgData['dbReferrence'],
+  ) {
+    const reply = dbReferrence?.broadcastMsgs.get(channelId) ?? dbReferrence;
+    return reply?.messageId
+      ? [getJumpButton(username, { channelId, serverId, messageId: reply.messageId })]
+      : undefined;
+  }
+
+  private getCompactFormat(
+    message: Message<true>,
+    connection: connectedList,
+    opts: BroadcastOpts & {
+      username: string;
+      censoredContent: string;
+      referredContent: string | undefined;
+    },
+    author: { username: string; avatarURL: string },
+    jumpButton?: ActionRowBuilder<ButtonBuilder>[],
+  ): WebhookMessageCreateOptions {
+    const contents = {
+      normal: message.content,
+      referred: opts.referredContent,
+      censored: opts.censoredContent,
+    };
+
+    return getCompactMessageFormat(connection, opts, {
+      servername: trimAndCensorBannedWebhookWords(message.guild.name),
+      totalAttachments: message.attachments.size,
+      contents,
+      author,
+      jumpButton,
+    });
+  }
+
+  private getEmbedFormat(
+    message: Message<true>,
+    connection: connectedList,
+    hub: Hub,
+    opts: BroadcastOpts & {
+      username: string;
+      censoredContent: string;
+      referredContent: string | undefined;
+    },
+    jumpButton?: ActionRowBuilder<ButtonBuilder>[],
+  ): WebhookMessageCreateOptions {
+    const embeds = buildNetworkEmbed(message, opts.username, opts.censoredContent, {
+      attachmentURL: opts.attachmentURL,
+      referredContent: opts.referredContent,
+      embedCol: opts.embedColor,
+    });
+
+    return getEmbedMessageFormat(connection, hub, { jumpButton, embeds });
+  }
+
+  private addReplyMention(
+    messageFormat: WebhookMessageCreateOptions,
+    connection: connectedList,
+    referredMsgData?: ReferredMsgData,
+  ): WebhookMessageCreateOptions {
+
+    if (referredMsgData && connection.serverId === referredMsgData.dbReferrence?.guildId) {
+      const { dbReferredAuthor, dbReferrence } = referredMsgData;
+      const replyMention = `${getReplyMention(dbReferredAuthor)}`;
+
+      messageFormat.content = `${replyMention} ${messageFormat.content ?? ''}`;
+      messageFormat.allowedMentions = {
+        ...messageFormat.allowedMentions,
+        users: [...(messageFormat.allowedMentions?.users ?? []), dbReferrence.authorId],
+      };
+    }
+
+    return messageFormat;
   }
 
   private async resolveAttachmentURL(message: Message) {
-    return message.attachments.first()?.url ?? (await getAttachmentURL(message.content));
+    return (
+      message.attachments.first()?.url ?? (await getAttachmentURL(message.content)) ?? undefined
+    );
   }
 
   private getReferredContent(data: ReferredMsgData) {
@@ -172,7 +272,6 @@ export default class MessageCreate extends BaseEventListener<'messageCreate'> {
     connection: connectedList | null;
     hubConnections: connectedList[] | null;
   }> {
-    // check if the message was sent in a network channel
     const connectionHubId = await getConnectionHubId(message.channelId);
     if (!connectionHubId) return { connection: null, hubConnections: null };
 

--- a/src/events/webhooksUpdate.ts
+++ b/src/events/webhooksUpdate.ts
@@ -1,7 +1,6 @@
-import BaseEventListener from '#main/core/BaseEventListener.js';
-import { isGuildTextBasedChannel } from '#utils/ChannelUtls.js';
-import { updateConnection } from '#utils/ConnectedListUtils.js';
 import { emojis } from '#main/config/Constants.js';
+import BaseEventListener from '#main/core/BaseEventListener.js';
+import { updateConnection } from '#utils/ConnectedListUtils.js';
 import db from '#utils/Db.js';
 import { t } from '#utils/Locale.js';
 import Logger from '#utils/Logger.js';
@@ -35,7 +34,7 @@ export default class Ready extends BaseEventListener<'webhooksUpdate'> {
         ? await channel.client.channels.fetch(connection.channelId)
         : channel;
 
-      if (isGuildTextBasedChannel(networkChannel)) {
+      if (networkChannel?.isSendable()) {
         await networkChannel.send(t('misc.webhookNoLongerExists', 'en', { emoji: emojis.info }));
       }
     }

--- a/src/utils/network/messageFormatters.ts
+++ b/src/utils/network/messageFormatters.ts
@@ -23,7 +23,7 @@ const getReplyContent = (content: string | undefined, profFilter: boolean) => {
 };
 
 export const getReplyMention = (dbReferredAuthor: UserData | null) => {
-  if (!dbReferredAuthor?.mentionOnReply) return null;
+  if (!dbReferredAuthor?.mentionOnReply) return '';
   return userMention(dbReferredAuthor.id);
 };
 


### PR DESCRIPTION
Refactor the network module to simplify message checks and broadcasting

This pull request includes the following changes:

1. Added a new check function `checkBlockedWords` to check if the message contains any words from the hub's blocked words list.
2. Improved the `checkSpam` function to only check for spam if the spam filter setting is enabled.
3. Refactored some of the check functions to use the `Awaitable` type from Discord.js.
4. Made the `hub` parameter in the `CheckFunctionOpts` interface include the `msgBlockList` property from the `MessageBlockList` model.
5. Simplified the `checkHubLock` function by removing the `async` keyword.
6. Simplified the `checkMessageLength` and `checkAttachments` functions by removing the `async` keyword.
7. Improved the `checkProfanityAndSlurs` function by separating the handling of profanity and slurs.

These changes aim to enhance the moderation capabilities of the network by introducing blocked words checking and improving the spam detection mechanism.