### PR TITLE
fix(blacklist list): show expiring blacklists first

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,11 +36,10 @@ type userBan {
   reason String
 }
 
-type hubBlacklist {
-  reason      String
-  expires     DateTime?
-  moderatorId String?
-  hubId       String    @db.ObjectId
+enum BlockWordAction {
+  BLOCK_MESSAGE
+  BLACKLIST
+  SEND_ALERT
 }
 
 enum InfractionType {
@@ -53,13 +52,6 @@ enum InfractionStatus {
   REVOKED
   APPEALED
 }
-
-enum BlockWordAction {
-  BLOCK_MESSAGE
-  BLACKLIST
-  SEND_ALERT
-}
-
 model UserInfraction {
   id          String           @id @default(nanoid(10)) @map("_id")
   userId      String           @db.String

--- a/src/commands/slash/Main/blacklist/list.ts
+++ b/src/commands/slash/Main/blacklist/list.ts
@@ -39,6 +39,7 @@ export default class ListBlacklists extends BlacklistCommand {
         ? await db.serverInfraction.findMany(query)
         : await db.userInfraction.findMany({
           where: query.where,
+          orderBy: { expiresAt: 'asc' },
           include: { userData: { select: { username: true } } },
         });
 

--- a/src/modules/Pagination.ts
+++ b/src/modules/Pagination.ts
@@ -136,7 +136,13 @@ export class Pagination {
       return pageNumber - 1; // Convert to 0-based index
     }
     catch (error) {
-      Logger.error('Page selection error:', error);
+      if (
+        !error.message.includes(
+          'Collector received no interactions before ending with reason: time',
+        )
+      ) {
+        Logger.error('Page selection error:', error);
+      }
       return null;
     }
   }

--- a/src/types/locale.d.ts
+++ b/src/types/locale.d.ts
@@ -179,7 +179,7 @@ export type TranslationKeys = {
   'errors.unknownServer': 'emoji';
   'errors.unknownNetworkMessage': 'emoji';
   'errors.userNotFound': 'emoji';
-  'errors.blacklisted': 'emoji';
+  'errors.blacklisted': 'emoji' | 'hub';
   'errors.userBlacklisted': 'emoji';
   'errors.serverBlacklisted': 'emoji';
   'errors.serverNotBlacklisted': 'emoji';


### PR DESCRIPTION
This pull request addresses the issue in the blacklist list where expiring blacklists were not being displayed first. Now, with this fix, expiring blacklists will be shown at the top of the list for better visibility and management.

### Changes Made
- Updated the sorting logic to prioritize expiring blacklists.
- Fixed the display issue in the blacklist list.

### Related Issue
Resolves #113
