### PR TITLE
fix: fix replied message showing no content across different connection modes

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -111,13 +111,7 @@ export default class MessageCreate extends BaseEventListener<'messageCreate'> {
       embedColor: connection.embedColor as HexColorString,
     });
 
-    await storeMessageData(
-      message,
-      sendResult,
-      connection.hubId,
-      connection.compact ? ConnectionMode.Compact : ConnectionMode.Embed,
-      referredMsgData.dbReferrence,
-    );
+    await storeMessageData(message, sendResult, connection.hubId, referredMsgData.dbReferrence);
   }
 
   private async fetchReferredMessage(message: Message<true>): Promise<Message | null> {
@@ -277,10 +271,11 @@ export default class MessageCreate extends BaseEventListener<'messageCreate'> {
 
   private getReferredContent(data: ReferredMsgData) {
     if (data.referredMessage && data.dbReferrence) {
-      const messagesRepliedTo =
-        data.dbReferrence.broadcastMsgs.get(data.referredMessage.channelId) ?? data.dbReferrence;
+      const mode =
+        data.dbReferrence.broadcastMsgs.get(data.referredMessage.channelId)?.mode ??
+        ConnectionMode.Compact; // message is an OriginalMessage (user message)
 
-      return getReferredContent(data.referredMessage, messagesRepliedTo.mode);
+      return getReferredContent(data.referredMessage, mode);
     }
   }
 

--- a/src/tasks/storeMsgTimestamps.ts
+++ b/src/tasks/storeMsgTimestamps.ts
@@ -9,6 +9,7 @@ export default async () => {
   const timestampsObj = await getRedis().hgetall(`${RedisKeys.msgTimestamp}`);
 
   Object.entries(timestampsObj).forEach(async ([channelId, timestamp]) => {
+    // FIXME: Errors happens that says "record to update not found"
     await updateConnection({ channelId }, { lastActive: new Date(parseInt(timestamp)) });
     Logger.debug(`Stored message timestamps for channel ${channelId} from cache to db.`);
     await getRedis().hdel(`${RedisKeys.msgTimestamp}`, channelId);

--- a/src/utils/network/helpers.ts
+++ b/src/utils/network/helpers.ts
@@ -71,7 +71,7 @@ export const getReferredMsgData = async (
   // fetch the acttual user ("referredMessage" is a webhook message)
   const referredAuthor = await client.users.fetch(dbReferrenceRaw.authorId).catch(() => null);
   const dbReferredAuthor = await client.userManager.getUser(dbReferrenceRaw.authorId);
-  const broadcastedMessages = await getBroadcasts(referredMessage.id, dbReferrenceRaw.hubId);
+  const broadcastedMessages = await getBroadcasts(dbReferrenceRaw.messageId, dbReferrenceRaw.hubId);
 
   const dbReferrence = {
     ...dbReferrenceRaw,

--- a/src/utils/network/messageUtils.ts
+++ b/src/utils/network/messageUtils.ts
@@ -5,7 +5,6 @@ import type { Message, Snowflake } from 'discord.js';
 import isEmpty from 'lodash/isEmpty.js';
 
 export interface OriginalMessage {
-  mode: number;
   hubId: string;
   messageId: string;
   guildId: string;
@@ -38,11 +37,7 @@ export const getOriginalMessage = async (originalMsgId: string) => {
 
   if (isEmpty(res)) return null;
 
-  return {
-    ...res,
-    mode: parseInt(res.mode),
-    timestamp: parseInt(res.timestamp),
-  } as OriginalMessage;
+  return { ...res, timestamp: parseInt(res.timestamp) } as OriginalMessage;
 };
 
 export const addBroadcasts = async (

--- a/src/utils/network/storeMessageData.ts
+++ b/src/utils/network/storeMessageData.ts
@@ -31,13 +31,11 @@ export default async (
   message: Message,
   broadcastResults: NetworkWebhookSendResult[],
   hubId: string,
-  mode: ConnectionMode,
   dbReference?: OriginalMessage | null,
 ) => {
   if (!message.inGuild()) return;
 
   await storeMessage(message.id, {
-    mode,
     hubId,
     messageId: message.id,
     authorId: message.author.id,
@@ -63,7 +61,7 @@ export default async (
       return;
     }
     validBroadcasts.push({
-      mode,
+      mode: res.mode,
       messageId: res.messageRes.id,
       channelId: res.messageRes.channel_id,
       originalMsgId: message.id,


### PR DESCRIPTION
Simplify the `storeMessageData` function by removing the unused `mode` 
parameter and refactoring the `await storeMessageData` call in 
`MessageCreate` to use fewer arguments. Address error handling in the 
`storeMsgTimestamps` task by adding a FIXME comment for a specific 
error case. Additionally, enhance the error response logic in the 
`EditMessage` command to improve user feedback during modal 
interactions.